### PR TITLE
Fixes rake task name typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ rake parsers:milkyway:all
 rake search:rebuild
 ```
 
-The ```rake parsers:milkyway:all``` rake task fetches the DU data set from http://research.amnh.org/users/abbott/dudata/ and stores it into Postgres.
+The ```rake parser:milkyway:all``` rake task fetches the DU data set from http://research.amnh.org/users/abbott/dudata/ and stores it into Postgres.
 
 The ```rake search:rebuild``` builds search index for all these data sets.
 


### PR DESCRIPTION
Changed rake parsers:milky way:all to rake parser:milkyway:all in README.md per rake task name in parser.rake.
